### PR TITLE
- fix bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,10 +55,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'androidx.recyclerview:recyclerview:1.2.0-beta01'
+    implementation 'androidx.viewpager2:viewpager2:1.1.0-alpha01'
     /**
      *   Dagger2
      *   https://github.com/google/dagger
@@ -125,15 +126,15 @@ dependencies {
     /**
      *
      */
-    implementation "com.github.bumptech.glide:glide:4.9.0"
+    implementation "com.github.bumptech.glide:glide:4.11.0"
 
     /**
      * Room
      * https://developer.android.com/reference/androidx/room/package-summary?hl=ru
      */
-    implementation 'androidx.room:room-runtime:2.3.0-alpha04'
-    implementation 'androidx.room:room-ktx:2.3.0-alpha04'
-    kapt "androidx.room:room-compiler:2.3.0-alpha04"
+    implementation 'androidx.room:room-runtime:2.3.0-beta01'
+    implementation 'androidx.room:room-ktx:2.3.0-beta01'
+    kapt "androidx.room:room-compiler:2.3.0-beta01"
 
     /**
      * Unit test dependencies

--- a/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/album/AlbumPhotoListAdapter.kt
+++ b/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/album/AlbumPhotoListAdapter.kt
@@ -53,7 +53,7 @@ class AlbumPhotoListAdapter(
 
     override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
 //        println("🤔 SingleViewBinderAdapter onBindViewHolder() position: $position, holder: $holder")
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), position)
     }
 
     inner class ImageViewHolder(
@@ -61,13 +61,13 @@ class AlbumPhotoListAdapter(
         private val onItemClick: ((ImageView, Photo, Int) -> Unit)? = null
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(model: Photo) {
+        fun bind(model: Photo, position: Int) {
 
             val imageView = binding.ivPhoto
 
             setImageUrl(model.url!!)
 
-            binding.ivPhoto.transitionName = binding.ivPhoto.resources.getString(R.string.photo_transition_name) + model.url
+            binding.ivPhoto.transitionName = binding.ivPhoto.resources.getString(R.string.photo_transition_name) + position
 
             binding.root.setOnClickListener {
                 onItemClick?.invoke(imageView, model, bindingAdapterPosition)

--- a/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/photo/PhotoFragment.kt
+++ b/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/photo/PhotoFragment.kt
@@ -1,5 +1,6 @@
 package com.example.appsample.framework.presentation.profile.screens.photo
 
+import android.animation.LayoutTransition
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import androidx.fragment.app.Fragment
 import com.example.appsample.R
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
+
 
 class PhotoFragment : Fragment() {
 
@@ -23,6 +25,10 @@ class PhotoFragment : Fragment() {
 
         val imageView = view.findViewById<ImageView>(R.id.image)
         imageView.transitionName = getString(R.string.photo_transition_name) + position
+        val transition = LayoutTransition()
+        transition.setAnimateParentHierarchy(false)
+        container?.layoutTransition = transition
+        container?.layoutTransition?.setAnimateParentHierarchy(false)  // to prevent bug of animation viewPager https://stackoverflow.com/questions/59660691/java-lang-illegalstateexception-page-can-only-be-offset-by-a-positive-amount
 
 
         if (imageView != null) {

--- a/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/photo/PhotoPagerFragment.kt
+++ b/app/src/main/java/com/example/appsample/framework/presentation/profile/screens/photo/PhotoPagerFragment.kt
@@ -96,9 +96,6 @@ constructor(
         val transition = TransitionInflater.from(context)
             .inflateTransition(R.transition.image_shared_element_transition)
         sharedElementEnterTransition = transition
-
-        this.binding.root.layoutTransition?.setAnimateParentHierarchy(false)  // to prevent bug of animation viewPager https://stackoverflow.com/questions/59660691/java-lang-illegalstateexception-page-can-only-be-offset-by-a-positive-amount
-
         setEnterSharedElementCallback(
             object : SharedElementCallback() {
                 override fun onMapSharedElements(names: List<String>, sharedElements: MutableMap<String, View>) {
@@ -109,6 +106,7 @@ constructor(
                         currentFragment = _binding!!.viewPager[0]
                     }
                     Log.d(TAG, "names.get(0) " + names[0])
+                    Log.d(TAG, "names size: ${names.size}")
                     sharedElements[names[0]] = currentFragment.findViewById(R.id.image)
                 }
             })
@@ -143,6 +141,7 @@ constructor(
                         override fun onPageSelected(position: Int) {
                             super.onPageSelected(position)
                             sharedViewModel.select(position)
+                            Log.d(TAG, "sharedViewModel.selected.value!!: ${sharedViewModel.selected.value}")
                         }
                     })
                     var counter = 0


### PR DESCRIPTION
* fixed crash of AlbumFragment if exits from PagerFragment before transition completes : IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.


* fixed crash caused by ViewPager2 library by setting AnimateParentHierarchy to false in PhotoFragment : IllegalStateException: Page can only be offset by a positive amount, not by -28